### PR TITLE
Add SetLevel method to the logger interface

### DIFF
--- a/golog/golog.go
+++ b/golog/golog.go
@@ -202,6 +202,11 @@ func (logger *Logger) LogLevel(level log.Level) bool {
 	return logger.threshold >= level
 }
 
+// SetLevel sets the logger to a new log level
+func (logger *Logger) SetLevel(level log.Level) {
+	logger.threshold = level
+}
+
 // Close does nothing and is just here so that Logger satisfies the log.Logger
 // interface.
 func (logger *Logger) Close() error { return nil }

--- a/log.go
+++ b/log.go
@@ -111,5 +111,8 @@ type Logger interface {
 	// LogLevel returns true if the log level is at or below the level argument.
 	LogLevel(level Level) bool
 
+	// SetLevel sets the logger to a new log level
+	SetLevel(level Level)
+
 	io.Closer
 }


### PR DESCRIPTION
I use your package for logging in a command line program. At the beginning it was enough for me to set the log level via command line paramets and initialize the logger via `stdlog.GetFromFlags()` but now that my program has grown I want to use configuration files as well. Thats why I need to be able to set the level of a logger during program execution. I thought maybe you want to merge that change into your base repo as well, even though I am aware of that this might break some stuff since it adds a new method to the interface
