### PR TITLE
Allow levels to be printed as string

### DIFF
--- a/golog/golog.go
+++ b/golog/golog.go
@@ -262,19 +262,8 @@ func writeInt(tmp *[23]byte, intLength, position, integer int) {
 	}
 }
 
-var levelPrefixes = []string{
-	" EMERGENCY ",
-	" ALERT ",
-	" CRITICAL ",
-	" ERROR ",
-	" WARNING ",
-	" NOTICE ",
-	" INFO ",
-	" DEBUG ",
-}
-
 func addLevel(buffer *bytes.Buffer, level log.Level) {
-	buffer.WriteString(levelPrefixes[level])
+	buffer.WriteString(fmt.Sprintf(" %s ", level))
 }
 
 func addMessage(buffer *bytes.Buffer, args ...interface{}) {

--- a/log.go
+++ b/log.go
@@ -19,6 +19,17 @@ const (
 	Debug
 )
 
+var levelPrefixes = []string{
+	"EMERGENCY",
+	"ALERT",
+	"CRITICAL",
+	"ERROR",
+	"WARNING",
+	"NOTICE",
+	"INFO",
+	"DEBUG",
+}
+
 // Logger is a common interface for logging libraries.
 type Logger interface {
 	// Emergency logs with an emergency level.
@@ -112,4 +123,8 @@ type Logger interface {
 	LogLevel(level Level) bool
 
 	io.Closer
+}
+
+func (l Level) String() string {
+	return levelPrefixes[l]
 }


### PR DESCRIPTION
Adding a default level to string so there is no need to write one when implementing a custom formatter.